### PR TITLE
Add support for native enums in discrinator

### DIFF
--- a/src/openapi-generator.ts
+++ b/src/openapi-generator.ts
@@ -727,6 +727,13 @@ export class OpenAPIGenerator {
         return;
       }
 
+      if (isZodType(value, 'ZodNativeEnum')) {
+        Object.values(value._def.values).forEach((enumValue: string) => {
+          mapping[enumValue] = this.generateSchemaRef(refId);
+        });
+        return;
+      }
+
       const literalValue = value?._def.value;
 
       // This should never happen because Zod checks the disciminator type but to keep the types happy


### PR DESCRIPTION
Currently discriminating on a field, which changes between different NativeEnum types causes model definition to be incorrect as mapping from discriminator field doesn't map to each of the enum values. 

I used the same solution that existed for ZodEnum, and applied it for ZodNativeEnum